### PR TITLE
fixing node example and updating package versions.

### DIFF
--- a/node_test.js
+++ b/node_test.js
@@ -1,10 +1,23 @@
 // a very simple test to ensure this works in node
 // in conjunction with the web-audio-api module.
 // see the index.html file for individual ugen tests.
+setupForNode();
+const Gibberish = require('./build/gibberish.js').init();
+const sineWave = new Gibberish.Sine();
+sineWave.connect();
 
-// must be required AND placed in the global scope 
-// before initializing Gibberish!
-AudioContext = require('web-audio-api').AudioContext
-
-var Gibberish = require('./build/gibberish.js').init(),
-    a = new Gibberish.Sine().connect()
+function setupForNode() {
+  window = global;
+  document = {};
+  const NodeAudioContext = require('web-audio-api').AudioContext;
+  const Speaker = require('speaker');
+  AudioContext = function () {
+      const context = new NodeAudioContext();
+      context.outStream = new Speaker({
+        channels: context.format.numberOfChannels,
+        bitDepth: context.format.bitDepth,
+        sampleRate: context.sampleRate
+      });
+      return context;
+  };
+}

--- a/node_tonic_example.js
+++ b/node_tonic_example.js
@@ -1,0 +1,21 @@
+setupForNode();
+const Gibberish = require('gibberish-dsp').init();
+const sineWave = new Gibberish.Sine();
+console.log(Gibberish);
+
+// boilerplate for node. see node_test.js for a Speaker implementation
+function setupForNode() {
+  window = global;
+  document = {};
+  const NodeAudioContext = require('web-audio-api').AudioContext;
+  const stream = require('stream');
+  AudioContext = function () {
+      const context = new NodeAudioContext();
+      const outStream = new stream.Stream();
+      outStream.writable = true;
+      outStream.write = () => true;
+      outStream.end = () => {};
+      context.outStream = outStream;
+      return context;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gibberish-dsp",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Gibberish is designed to be a fast audio API for browser-based synthesis. It currently runs in Chrome, Safari 6+ and Firefox. It is 73 KB after minification.",
   "main": "./build/gibberish.js",
   "scripts": {
@@ -12,14 +12,17 @@
     "node": ">=0.10.26"
   },
   "devDependencies": {
-    "connect": "^2.25.7",
-    "serve-static": "^1.5.3",
-    "uglify-js": "^2.4.15"
+    "connect": "^3.4.1",
+    "serve-static": "^1.10.2",
+    "speaker": "^0.2.6",
+    "uglify-js": "^2.6.1",
+    "web-audio-api": "^0.2.2"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/charlieroberts/Gibberish"
   },
+  "tonicExampleFilename": "./node_tonic_example.js",
   "keywords": [
     "audio",
     "music",


### PR DESCRIPTION
Also adding a Tonic example (supported by NPM).
After pulling in these changes, you can `npm publish` and
https://tonicdev.com/npm/gibberish-dsp will work.

This will fix issue #11 
